### PR TITLE
Fix `/prompt` command and add Markdown support

### DIFF
--- a/main.py
+++ b/main.py
@@ -310,9 +310,9 @@ def handle_message(message):
 
     # Send the response back to the user
     if message.chat.type == "private":
-        bot.send_message(message.chat.id, response.choices[0].message.content + user_log)
+        bot.send_message(message.chat.id, response.choices[0].message.content + user_log, parse_mode="Markdown")
     else:
-        bot.reply_to(message, response.choices[0].message.content + user_log)
+        bot.reply_to(message, response.choices[0].message.content + user_log, parse_mode="Markdown")
 
     # Формируем лог работы для админа
     admin_log = (f"Запрос {request_number}: {request_tokens} за ¢{round(request_price, 3)}\n"

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import json
 import os
 import datetime
 
+from telebot.util import extract_arguments
 
 DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
 PRICE_1K = 0.002  # price per 1k rokens in USD
@@ -193,7 +194,8 @@ def handle_prompt_command(message):
     user = message.from_user
     answer = ""
 
-    prompt = message.text[len("/prompt"):].strip()
+    # Получаем аргументы команды (текст после /prompt)
+    prompt = extract_arguments(message.text)
 
     # Если юзер есть в базе, то записываем промпт, иначе просим его зарегистрироваться
     if is_user_exists(user.id):


### PR DESCRIPTION
- Add new extract_arguments() func from telebot.util lib (fixes https://github.com/kxkw/chatgpt-telegram-bot/issues/34)
- Add Markdown parsing to bot messages via telegram (closes https://github.com/kxkw/chatgpt-telegram-bot/issues/35)